### PR TITLE
Fix prettier config with ejs

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,11 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "overrides": [
+    {
+      "files": "src/views/*.ejs",
+      "options": {
+        "parser": "angular"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Configure prettier to be the same as VSCode.