### PR TITLE
Return empty json `{}` if no unit found by `q` or `acro`

### DIFF
--- a/src/services/unit.service.js
+++ b/src/services/unit.service.js
@@ -11,7 +11,7 @@ async function get (params) {
   const unitList = await searchUnits(q, lang);
 
   if (unitList.length === 0) {
-    return unitList;
+    return {};
   } else if (unitList.length === 1) {
     return await getUnit(unitList[0].acronym, lang);
   } else {
@@ -48,7 +48,7 @@ async function getUnit (acro, lang) {
 
   const results = await cadidbService.sendQuery(query, values, 'getUnit');
   if (results.length !== 1) {
-    return;
+    return {};
   }
   const dict = results[0];
   const unitPath = await getUnitPath(dict.hierarchie, lang);

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -39,11 +39,11 @@ describe('Test API Unit ("/api/unit")', () => {
 
     let response = await request(app).get('/api/unit?q=drebin&hl=fr');
     expect(response.statusCode).toBe(200);
-    expect(JSON.parse(response.text)).toStrictEqual([]);
+    expect(JSON.parse(response.text)).toStrictEqual({});
 
-    response = await request(app).get('/api/unit?acro=mandalo&hl=fr');
+    response = await request(app).get('/api/unit?acro=xxx&hl=fr');
     expect(response.statusCode).toBe(200);
-    expect(response.text).toBe('');
+    expect(JSON.parse(response.text)).toStrictEqual({});
   });
 
   test('It should return a unit list', async () => {


### PR DESCRIPTION
-- Also if more than 1 unit found by `acro`