### PR TITLE
Remove `workflow_run` condition in GitHub Actions Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Build image
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
 
       - name: Build image
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,23 +1,15 @@
 name: Build
 
-on:
-  workflow_run:
-    workflows:
-      - 'Test'
-    types:
-      - completed
+on: push
 
 jobs:
   build:
-    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     name: Build
 
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Build image
         run: |


### PR DESCRIPTION
`workflow_run` is limited in our use case. 
See https://stackoverflow.com/questions/63343937/how-to-use-the-github-actions-workflow-run-event