### PR TITLE
Simplify `ansible_python_interpreter`

### DIFF
--- a/ansible/inventory/dev.yml
+++ b/ansible/inventory/dev.yml
@@ -4,7 +4,7 @@ all:
       ansible_connection: local
       ansible_host: localhost
       openshift_namespace: svc0012d-search-engine
-      ansible_python_interpreter: '{{searchapisible_suitcase_dir}}/bin/python3'
+      ansible_python_interpreter: '{{ ansible_playbook_python }}'
   vars:
     routes_availability: private
     hostnames:

--- a/ansible/inventory/prod.yml
+++ b/ansible/inventory/prod.yml
@@ -4,7 +4,7 @@ all:
       ansible_connection: local
       ansible_host: localhost
       openshift_namespace: svc0012p-search-engine
-      ansible_python_interpreter: '{{searchapisible_suitcase_dir}}/bin/python3'
+      ansible_python_interpreter: '{{ ansible_playbook_python }}'
   vars:
     routes_availability: public
     hostnames:

--- a/ansible/inventory/staging.yml
+++ b/ansible/inventory/staging.yml
@@ -4,7 +4,7 @@ all:
       ansible_connection: local
       ansible_host: localhost
       openshift_namespace: svc0012t-search-engine
-      ansible_python_interpreter: '{{searchapisible_suitcase_dir}}/bin/python3'
+      ansible_python_interpreter: '{{ ansible_playbook_python }}'
   vars:
     routes_availability: private
     hostnames:

--- a/ansible/searchapisible
+++ b/ansible/searchapisible
@@ -60,7 +60,6 @@ ensure_oc4_login () {
 ensure_ansible
 
 declare -a ansible_args
-ansible_args=(-e "searchapisible_suitcase_dir=$PWD/ansible-deps-cache")
 inventory_mode="dev"
 cluster_url="https://api.ocpitsd0001.xaas.epfl.ch:6443"
 while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
`searchapisible_suitcase_dir` not needed for `ansible_python_interpreter`.